### PR TITLE
Use full path to mecab on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Yomitan MeCab Installer
 
+**MAC DOESN'T SEEM TO WORK RIGHT NOW. IF YOU KNOW HOW TO FIX IT, PLEASE MAKE A PR.**
+
 Installs the files required to run [MeCab](https://taku910.github.io/) in [Yomitan](https://github.com/TheMoeWay/yomitan/).
 Python and MeCab have to be installed separately.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Yomitan MeCab Installer
 
-**MAC DOESN'T SEEM TO WORK RIGHT NOW. IF YOU KNOW HOW TO FIX IT, PLEASE MAKE A PR.**
-
 Installs the files required to run [MeCab](https://taku910.github.io/) in [Yomitan](https://github.com/TheMoeWay/yomitan/).
 Python and MeCab have to be installed separately.
 

--- a/mecab.py
+++ b/mecab.py
@@ -21,7 +21,9 @@ from __future__ import print_function
 import json
 import sys
 import os
+import platform
 import re
+import shutil
 import struct
 import subprocess
 import threading
@@ -101,8 +103,8 @@ class Mecab:
     def get_executable_path(self):
         if os.name == 'nt':
             return self.get_nt_executable_path()
-        elif os.name == 'posix':
-            return self.get_posix_executable_path()
+        if sys.platform == 'darwin':
+            return self.get_darwin_executable_path()
         return 'mecab'
 
     def get_nt_executable_path(self):
@@ -128,7 +130,7 @@ class Mecab:
         # assume it exists in %PATH%
         return 'mecab.exe'
 
-    def get_posix_executable_path(self):
+    def get_darwin_executable_path(self):
         # check %PATH%
         if shutil.which('mecab') != None:
             return 'mecab'

--- a/mecab.py
+++ b/mecab.py
@@ -101,6 +101,8 @@ class Mecab:
     def get_executable_path(self):
         if os.name == 'nt':
             return self.get_nt_executable_path()
+        elif os.name == 'posix':
+            return self.get_posix_executable_path()
         return 'mecab'
 
     def get_nt_executable_path(self):
@@ -125,6 +127,17 @@ class Mecab:
             return path
         # assume it exists in %PATH%
         return 'mecab.exe'
+
+    def get_posix_executable_path(self):
+        # check %PATH%
+        if shutil.which('mecab') != None:
+            return 'mecab'
+        # assume mecab is installed via Homebrew
+        if platform.processor() == 'arm':
+            # use default Apple Silicon path
+            return '/opt/homebrew/bin/mecab'
+        # use default macOS Intel path
+        return '/usr/local/bin/mecab'
 
     def parse(self, text):
         parsed_lines = []

--- a/mecab.py
+++ b/mecab.py
@@ -103,7 +103,7 @@ class Mecab:
     def get_executable_path(self):
         if os.name == 'nt':
             return self.get_nt_executable_path()
-        if sys.platform == 'darwin':
+        if sys.platform == 'darwin': # macOS
             return self.get_darwin_executable_path()
         return 'mecab'
 


### PR DESCRIPTION
## The issue

1. macOS GUI applications started from Spotlight, Launchpad, or Finder won't have the same `PATH` as in the terminal. They'll have something like `PATH=/usr/bin:/bin:/usr/sbin:/sbin`.
2. When the script runs through `NativeMessaging`, it inherits environment variables from its parent. And because there is no `mecab` in `PATH`, `FileNotFoundError` occurs when script tries to open a process: https://github.com/themoeway/yomitan-mecab-installer/blob/87749d046503154d8b1efb7783b03d2a4d75ad76/mecab.py#L89-L94


Resources:
- [Developer Apple Forum Thread](https://forums.developer.apple.com/forums/thread/74371)
- [Setting PATH for macOS GUI Apps](https://www.bounga.org/tips/2020/04/07/instructs-mac-os-gui-apps-about-path-environment-variable)

## Fix

There are 4 possible ways to fix this:
1. Add the path to `/etc/paths`
2. Open the browser via the terminal
3. Create symlink for `mecab` in one of the paths `/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`
4. Change the script to use mecab's full path. <-- PR implements this