### PR TITLE
fix permission issue on MacOS with Chrome

### DIFF
--- a/install_mecab_for_yomitan.py
+++ b/install_mecab_for_yomitan.py
@@ -21,6 +21,7 @@ import os
 import json
 import copy
 import zipfile
+import shutil
 if sys.version_info[0] == 3:
     from urllib.request import urlretrieve
 elif sys.version_info[0] == 2:
@@ -198,8 +199,20 @@ def main():
                 script_path
             ))
         script_path = bat_path
-    manifest = manifest_get(browser, script_path, additional_extension_ids)
     manifest_install_data = platform_data['manifest_install_data'][browser]
+    # fix macos user dictionary permission issue
+    if platform_data['platform'] == 'mac':
+        script_path = os.path.join(manifest_install_data['path'], 'mecab.py')
+        try:
+            shutil.copy(os.path.join(DIR, 'mecab.py'), script_path)
+            print(f"File copied from {os.path.join(DIR, 'mecab.py')} to {script_path}")
+        except FileNotFoundError:
+            print("File not found.")
+        except PermissionError:
+            print("Permission denied.")
+        except Exception as e:
+            print(f"An error occurred: {e}")
+    manifest = manifest_get(browser, script_path, additional_extension_ids)
     for method in manifest_install_data['methods']:
         if method == 'file':
             manifest_install_file(manifest, manifest_install_data['path'])


### PR DESCRIPTION
Newer MacOS version have permission on user folder. So if the user download script and run on user folder (ex: Downloads), ther permisson issue will happen and can't connect mecab