### PR TITLE
macos : fix installation to correctly target the installation folder for mecab.py and dictionnaries

### DIFF
--- a/install_mecab_for_yomitan.py
+++ b/install_mecab_for_yomitan.py
@@ -237,18 +237,6 @@ def main():
             ))
         script_path = bat_path
     manifest_install_data = platform_data['manifest_install_data'][browser]
-    # fix macOS user dictionary permission issue
-    if platform_data['platform'] == 'mac':
-        script_path = os.path.join(manifest_install_data['path'], 'mecab.py')
-        try:
-            shutil.copy(os.path.join(DIR, 'mecab.py'), script_path)
-            print(f"File copied from {os.path.join(DIR, 'mecab.py')} to {script_path}")
-        except FileNotFoundError:
-            print("File not found.")
-        except PermissionError:
-            print("Permission denied.")
-        except Exception as e:
-            print(f"An error occurred: {e}")
     manifest = manifest_get(browser, script_path, additional_extension_ids)
     for method in manifest_install_data['methods']:
         if method == 'file':


### PR DESCRIPTION
By running experiment with Yomitan API, I noticed how changing from mecab or not wasn't changing anything and when checking the code of Yomitan itself, I noticed it should have parsed differently sentence.

After investigation, I realized the mecab integration while being "Successfuly connected" was in fact returning empty arrays.

After troubleshooting, I realized it was in fact the DIR that was set to the relative file of `mecab.py`, but thus it wouldn't find the dictionnary that were downloaded in the cloned repository.

By adding a env variable, and also suggesting to used to just hardcode it if it's easier for them, I was able to make parsing work differently 

Before : See how the parsed results is an empty array
![CleanShot 2025-11-19 at 10 21 03@2x](https://github.com/user-attachments/assets/a1e68b65-9834-4e26-afda-990e4963a3f6)

After, now the result is filled correctly 
![CleanShot 2025-11-19 at 11 30 42@2x](https://github.com/user-attachments/assets/561ce70d-3364-4e5c-81d2-62d08d745beb)
